### PR TITLE
Fix DnC Aggregator

### DIFF
--- a/fedlib/aggregators/aggregators.py
+++ b/fedlib/aggregators/aggregators.py
@@ -202,7 +202,10 @@ class DnC(object):
         for lst in benign_ids[1:]:
             intersection_set.intersection_update(lst)
 
-        # Convert the set back to a list
-        benign_ids = list(intersection_set)
-        benign_updates = updates[benign_ids, :].mean(dim=0)
+        if intersection_set:
+            # Convert the set back to a list
+            benign_ids = list(intersection_set)
+            benign_updates = updates[benign_ids, :].mean(dim=0)
+        else:
+            benign_updates = torch.zeros_like(inputs[0])
         return benign_updates


### PR DESCRIPTION
If the intersection set is empty, i.e. there are no clients in the gradient selection set, the aggregator returns a tensor of NaN updates. This PR handles that edge case by doing a 0-update instead.

To replicate the (probabilistic) error run an experiment with `num_clients: 3` and high input dimensionality in which the default aggregator parameters are likely to cause it after a small number of FL iterations.